### PR TITLE
FIX: ensure retry events run when CircuitBreaker is Closed or Half Open

### DIFF
--- a/dev-notes/14.0-CircuitBreaker2.md
+++ b/dev-notes/14.0-CircuitBreaker2.md
@@ -1,0 +1,48 @@
+# Circuit breaker and delayed event runner improvements
+
+## Motivation
+
+Circuit breaker only attempts to run retry events if it moves from open to closed. If a circuit breaker is set to allow > 1 failure before tripping to open (as is likely to be true in a production scenario), events set up for retry won't run if the circuit breaker never trips.
+
+`onSuccess()` will need to try to run events
+
+## DER -- don't run events if already running
+
+`DelayedEventRunner.runEvents()` sets the state to run on start. If `onSuccess()` calls `runEvents()`, it could lead to `runEvents()` being called while it's running.
+
+Plan
+
+-  In `runEvents()` if state is run or no events, return
+-  When running events finishes set state to stop (new state) so it won't be in run when `runEvents()` starts next time
+
+States
+
+-  Run - loop is running
+-  Stop - loop is done or stopped by external process
+-  Halt - abort signal received, stop loop; shutting down
+
+## CB - call runEvents() from onSuccess()
+
+Calling `runEvents()` from `onSuccess()` ensures that the next successful call to the service will run any events set up for retry. Changes to `runEvents()` above will ensure the `runEvents()` loop runs once and only once.
+
+## How to test
+
+DER gets a test suite
+
+-  [x] when no events are set up for retry, runEvents() does nothing
+-  [x] when events are set up for retry and DER is in run state, runEvents() does nothing
+-  [x] when events are set up for retry and DER is in stop state, runEvents() runs events
+
+New test for CB
+
+-  [x] when CB is closed and events are set up for retry, onSuccess() causes events to run
+
+The closed test covers half open too because `runEvents()` call is outside conditions for different states
+
+## Other
+
+Found an error in `ExpressCreateBackupRequestController` tests -- wasn't setting authZ data right for fakeAuthNZ, getting 403 errors
+
+All tests pass.
+
+**COMMIT: FIX: ensure retry events run when CircuitBreaker is Closed or Half Open**

--- a/src/backup-request/adapter/impl/ExpressCreateBackupRequestController.typeorm.spec.ts
+++ b/src/backup-request/adapter/impl/ExpressCreateBackupRequestController.typeorm.spec.ts
@@ -40,7 +40,7 @@ describe('ExpressCreateBackupRequestController - typeorm', () => {
 	});
 
 	const testUrl = '/api/backup-requests';
-	const fakeAuthHeader = 'fakeTypeORM|permission1';
+	const fakeAuthHeader = 'fakeTypeORM|post-backup-request';
 
 	const basePayload = {
 		apiVersion: '2022-05-22',

--- a/src/infrastructure/resilience/DelayedEventRunner.spec.ts
+++ b/src/infrastructure/resilience/DelayedEventRunner.spec.ts
@@ -1,0 +1,204 @@
+import { Result, ok, err } from '../../common/core/Result';
+import { BaseError } from '../../common/core/BaseError';
+
+import { DomainEventBus, IDomainEvent, IDomainEventSubscriber } from '../../common/domain/DomainEventBus';
+import { UniqueIdentifier } from '../../common/domain/UniqueIdentifier';
+
+import { UseCase } from '../../common/application/UseCase';
+
+import * as AdapterErrors from '../../common/adapter/AdapterErrors';
+
+import { CircuitBreakerStateValues, CircuitBreakerWithRetry, ConnectFailureErrorData } from './CircuitBreakerWithRetry';
+import { delay, Dictionary } from '../../common/utils/utils';
+import { DelayedEventRunner } from './DelayedEventRunner';
+
+const VERBOSE_LOGS = false; // set true to get verbose console.logs for event tracing
+interface TestUseCaseDTO {
+	id: UniqueIdentifier;
+	retryCount: number;
+}
+
+// this test suite isn't concerned about the adapter or service behavior, so only needs to check calls to the use case
+
+class TestUseCase implements UseCase<TestUseCaseDTO, Result<boolean, BaseError>> {
+	// private testAdapter: TestAdapter;
+
+	constructor() {
+		//testAdapter: TestAdapter) {
+		//this.testAdapter = testAdapter;
+	}
+
+	public async execute(request: TestUseCaseDTO): Promise<Result<boolean, BaseError>> {
+		if (VERBOSE_LOGS) console.log('TestUseCase request', request);
+		// return await this.testAdapter.test();
+		return ok(true);
+	}
+}
+
+class TestEvent implements IDomainEvent {
+	public eventTimestamp: Date;
+	public id: UniqueIdentifier;
+	public retryCount: number;
+
+	constructor(id: UniqueIdentifier) {
+		this.eventTimestamp = new Date();
+		this.id = id;
+		this.retryCount = 0;
+	}
+
+	getId(): UniqueIdentifier {
+		return this.id;
+	}
+}
+
+class TestSubscriber implements IDomainEventSubscriber<TestEvent> {
+	private useCase: TestUseCase;
+	private failedServices: Dictionary = {};
+
+	constructor(useCase: TestUseCase) {
+		this.setupSubscriptions();
+		this.useCase = useCase;
+	}
+
+	setupSubscriptions(): void {
+		DomainEventBus.subscribe(TestEvent.name, this.onEvent.bind(this));
+	}
+
+	public get failedServiceNames() {
+		return Object.keys(this.failedServices);
+	}
+
+	async onEvent(event: TestEvent): Promise<void> {
+		const id = event.getId();
+		const eventName = event.constructor.name;
+
+		if (VERBOSE_LOGS) console.log('subscriber event', id.value, event.retryCount, this.failedServiceNames);
+
+		if (Object.keys(this.failedServices).length > 0) {
+			// have connection checks
+			for (const serviceName in this.failedServices) {
+				if (VERBOSE_LOGS)
+					console.log(
+						'subscriber connection check for',
+						id.value,
+						serviceName,
+						this.failedServices[serviceName].isConnected()
+					);
+				if (!this.failedServices[serviceName].isConnected()) {
+					event.retryCount++;
+					this.failedServices[serviceName].addRetryEvent(event);
+					return; // something is down so no need to check further
+				}
+
+				// if it doesn't fail, don't need to check again
+				delete this.failedServices[serviceName];
+			}
+		}
+		try {
+			const result = await this.useCase.execute({ id, retryCount: event.retryCount });
+
+			if (result.isErr()) {
+				if (VERBOSE_LOGS)
+					console.log('subscriber use case error', event.id.value, event.retryCount, result.error.message);
+				const errorData = result.error.errorData as any;
+				if (errorData.isConnectFailure) {
+					if (errorData.serviceName && errorData.isConnected && !this.failedServices[errorData.serviceName]) {
+						this.failedServices[errorData.serviceName] = { isConnected: undefined, addRetryEvent: undefined };
+						this.failedServices[errorData.serviceName].isConnected = errorData.isConnected;
+						this.failedServices[errorData.serviceName].addRetryEvent = errorData.addRetryEvent;
+					}
+					if (errorData.addRetryEvent) {
+						event.retryCount++;
+						errorData.addRetryEvent(event);
+					}
+				}
+			} else {
+				if (VERBOSE_LOGS) console.log('subscriber use case ok', event.id.value, event.retryCount);
+			}
+		} catch (e) {
+			const { message, ...error } = e as BaseError;
+			console.log('subscriber error', message, error);
+		}
+	}
+}
+
+function getEvent(id: string) {
+	return new TestEvent(new UniqueIdentifier(id));
+}
+
+describe('DelayedEventRunner', () => {
+	test('when no events are set up for retry, calling runEvents() does not run the use case', async () => {
+		// Arrange
+		const abortController = new AbortController();
+
+		const delayedEventRunner = new DelayedEventRunner(abortController.signal, 20);
+		const useCase = new TestUseCase();
+		const subscriber = new TestSubscriber(useCase);
+		const useCaseSpy = jest.spyOn(useCase, 'execute');
+
+		// Act
+		delayedEventRunner.runEvents();
+		await delay(50);
+
+		// Assert
+		// use case should not run because no events
+		expect(useCaseSpy).toBeCalledTimes(0);
+	});
+
+	test('when events are set up for retry and DER is in Run state, runEvents() does not run', async () => {
+		// does not run because if DER is in Run state, it's already running; running twice can cause problems
+
+		// Arrange
+		const abortController = new AbortController();
+
+		const delayedEventRunner = new DelayedEventRunner(abortController.signal, 20);
+		const useCase = new TestUseCase();
+		const subscriber = new TestSubscriber(useCase);
+		const useCaseSpy = jest.spyOn(useCase, 'execute');
+
+		delayedEventRunner.addEvent(new TestEvent(new UniqueIdentifier('test-event-1')));
+		delayedEventRunner.addEvent(new TestEvent(new UniqueIdentifier('test-event-2')));
+		delayedEventRunner.setStateRun();
+
+		// Act
+		delayedEventRunner.runEvents();
+		await delay(50);
+
+		expect(delayedEventRunner.eventCount).toBe(2);
+		expect(delayedEventRunner.isStateRun()).toBe(true);
+		// retryEvents() exits before publishing events, so use case won't run in this test
+		expect(useCaseSpy).toBeCalledTimes(0);
+
+		// Cleanup
+		DomainEventBus.clearHandlers();
+		abortController.abort();
+		delay(20);
+	});
+
+	test('when events are set up for retry and DER is in Stop state, runEvents() runs events', async () => {
+		// Arrange
+		const abortController = new AbortController();
+
+		const delayedEventRunner = new DelayedEventRunner(abortController.signal, 20);
+		const useCase = new TestUseCase();
+		const subscriber = new TestSubscriber(useCase);
+		const useCaseSpy = jest.spyOn(useCase, 'execute');
+
+		delayedEventRunner.addEvent(new TestEvent(new UniqueIdentifier('test-event-1')));
+		delayedEventRunner.addEvent(new TestEvent(new UniqueIdentifier('test-event-2')));
+		// DER is in Stop state on create, so no need to set state
+
+		// Act
+		delayedEventRunner.runEvents();
+		await delay(50);
+
+		// Assert
+		expect(useCaseSpy).toBeCalledTimes(2);
+		expect(delayedEventRunner.eventCount).toBe(0);
+
+		// Cleanup
+		DomainEventBus.clearHandlers();
+		abortController.abort();
+		delay(20);
+	});
+});


### PR DESCRIPTION
Fixes a problem where failures that didn't trip the circuit breaker to open followed by successes left retry events waiting to run