### PR TITLE
More splunk logging

### DIFF
--- a/dev-notes/15.3-MoreBetterSplunk.md
+++ b/dev-notes/15.3-MoreBetterSplunk.md
@@ -66,7 +66,32 @@ So, this seems to work.
 
 ## Queue length can cause immediate retry after POST errors
 
--  [] Separate input queue and flushing queue.
--  [] On flush, copy input to flushing and empty input.
--  [] Use flushing queue to POST.
--  [] Append POST errors to flushing queue.
+-  [x] Separate input queue and flushing queue.
+-  [x] On flush, copy input to flushing and empty input.
+-  [x] Use flushing queue to POST.
+-  [x] Append POST errors to flushing queue.
+
+Somehow, I'm losing logs if I get a POST error. I get the POST error log, but lose logs until the POST works again (next successful works, but any in between are lost).
+
+Debugging, I see that the timeout isn't working like I expected either. After a connect failure, it doesn't retry if no new events arrive.
+
+After posting to trigger events that will cause a `flushQueue`, I see data is moving, but in small batches--my defaults for catchup are low. Splunk seems to be slow indexing the events, but the data is starting to appear in the log. So, I'm not losing data, just posting it slowly and Splunk was slow to ingest it. Which leaves me looking at the timer.
+
+I think the issue is where I reset the timer in `flushQueue`. `addEvent` started the timer, but if the timer expired and couldn't run `flushQueue`, it wasn't reset if there were logs waiting after the POST succeeded. Moved it out of the `catch` and reset timer if either queue has items.
+
+Basic testing procedure
+
+-  Start server with Splunk HEC enabled; see logs posted until `inQueue` and `outQueue` are empty
+-  Disable HEC
+-  Post a couple of requests and wait for `flushQueue` POST to timeout
+-  See it retry `flushQueue` and reset timer 2x
+-  Enable HEC
+-  See it retry `flushQueue` and move logs to Splunk
+
+I see it reset the timer, retry flush, reset timer, but then it doesn't retry flush. Ah! The timeout function only checks `inQueue`. It shouldn't check anything because `flushQueue` is controlling whether it runs or not correctly.
+
+And now things are looking better.
+
+Change post config--don't use alternate config values. And remove logs to stdout that showed status.
+
+**COMMIT: FEAT: separate input and output queues to avoid immediate retry after POST errors**

--- a/dev-notes/15.3-MoreBetterSplunk.md
+++ b/dev-notes/15.3-MoreBetterSplunk.md
@@ -1,0 +1,72 @@
+# More SplunkLogging improvements
+
+## Log queue problem
+
+Note: POST = post logs to Splunk
+
+The log queue (an array) accumulates logs until `SplunkLogger` POSTs them.
+
+`SplunkLogger` POSTs logs based on
+
+-  timeout -- every x milliseconds
+-  item size -- accumulated bytes of stringified items in the array
+-  item count -- queue.length
+
+If POST fails, `SplunkLogger` adds a failure log item to the queue and resets the queue size accumulator to 0 to avoid an immediate retry. It does not clear the queue, preserving log entries until they can be sent. There's a limit of 5 such entries at a time to avoid posting thousands of POST failure log entries.
+
+If the Splunk instance is down for a long time, the log queue could get large. If that happens, trying to POST the whole queue as a single batch could overwhelm Splunk with a huge batch of logs in a single POST or the resulting POST body could be too large. The HEC has a limit on the maximum message size; [Splunk documentation)](https://docs.splunk.com/Documentation/Splunk/9.0.1/Admin/Limitsconf#.5Bhttp_input.5D) says the limit is 800MB by default.
+
+I want to avoid overwhelming Splunk or blowing up a web server with a huge POST body.
+
+## Plan
+
+Define a value, `_maxPostItems`, which will be either a value from options or `_maxBatchItems` (if > 1) or 200. I'm choosing 200 as a default because:
+
+-  Consideration 1
+   -  Assume the average log is ~4KB
+   -  Assume the HEC limit may not be small enough to avoid overwhelming the instance with a large batch
+   -  Then
+      -  For short outages, 100 will likely empty the queue in a single POST
+      -  For long outages, 100 will empty the queue quickly while avoiding risks of batch or HEC limits
+-  Consideration 2
+   -  I don't see anything in the documentation stating how many log entries Splunk can handle in a single POST
+   -  But let's assume there's a practical limit
+   -  Then 200 is likely reasonable
+
+In `flushQueue()`, batch logs in `_maxPostItems` chunks. If `queue.length > _maxPostItems`, delay `_postRetryDelayMs` before POSTing the next batch. Also, `flushQueue()` will need to know if it's running to avoid competing with itself.
+
+Some of these concepts are similar to `DelayedEventRunner` and how it manages the loop that publishes events.
+
+-  [x] Fix alternate configuration items handling
+   -  If `_maxBatchBytes`, `_maxBatchItems`, or `_maxBatchWaitMs` aren't configured, `addEvent()` will always `flushQueue()`
+   -  But what if I simply want to post based on a subset of those items; I want the unconfigured item to be ignored
+   -  So, in configuration, default to -1 if any is configured or a safe value
+   -  And where these values are used, be sure they aren't -1
+-  [x] Add configuration values and initialize
+   -  Decided to make post retry = http timeout because naming would be confusing, so no separate value for that
+-  [x] `flushQueue() changes`
+   -  [x] Add `_queueFlushing` and default to false; set when starting `flushQueue()`
+   -  [x] `slice()` logs to post from the queue and `join()` them
+   -  [x] post logs
+   -  [x] If post succeeds, `splice()` entries off the queue
+   -  [x] If queue empty, zero `_httpErrorCount`
+   -  [x] If `_httpErrorCount` > 0, delay `_postRetryDelayMs`
+   -  [x] Loop until the queue is empty; don't check error count to avoid blocking post when reaching max error count
+   -  [x] Use `postErrored` to identify when the post errors (set true in catch) and stop loop
+
+I was trying to manage the `postErrored` concept with `_httpErrorCount`, but that was getting hairy. So I added `postErrored` because it is clearer, simpler, and more reliable.
+
+I tested to see log events flowed with HEC on. Posted once, saw it log, then turned HEC off and posted 100 times to the application. Each post to the application generates ~5 logs.
+
+After three consecutive POST error messages on the console (original POST or retry POSTs failing), and no changes to Splunk logs, I turned HEC on again. Next query saw the errors and the last few posts in the log. In a 15 minute period, I had 103 different backupRequestId values, which was consistent with my testing.
+
+So, this seems to work.
+
+**COMMIT: REFACTOR: change log flushing to limit POST size when recovering from Splunk connectivity failure**
+
+## Queue length can cause immediate retry after POST errors
+
+-  [] Separate input queue and flushing queue.
+-  [] On flush, copy input to flushing and empty input.
+-  [] Use flushing queue to POST.
+-  [] Append POST errors to flushing queue.

--- a/src/infrastructure/logging/pstBin.ts
+++ b/src/infrastructure/logging/pstBin.ts
@@ -24,7 +24,7 @@ const opts = {
 		maxBatchWaitMs: 5000,
 		maxBatchItems: 5,
 		maxBatchBytes: 2048,
-		maxRetries: 5,
+		maxPostRetries: 5,
 	},
 };
 const pst = buildTransport(opts);


### PR DESCRIPTION
Improve `SplunkLogger` by separating input and output queues to avoid immediate retry on next `addEvent`. Put all logic to decide if `flushQueue` should run in `flushQueue` to avoid differences. Improve timer restart decisions.